### PR TITLE
Update 14 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,21 +10,21 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "framer-motion": "^11.3.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "framer-motion": "^12.23.16",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
   },
   "devDependencies": {
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
-    "autoprefixer": "^10.4.19",
-    "eslint": "^8.57.0",
-    "eslint-plugin-react": "^7.34.2",
-    "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-react-refresh": "^0.4.7",
-    "postcss": "^8.4.39",
-    "tailwindcss": "^3.4.4",
-    "vite": "^5.3.1"
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.0.3",
+    "autoprefixer": "^10.4.21",
+    "eslint": "^9.36.0",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.20",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.13",
+    "vite": "^7.1.6"
   }
 }


### PR DESCRIPTION
## Dependency Updates

This PR updates the following dependencies to their latest versions:

- `framer-motion`: ^11.3.2 → 12.23.16
- `react`: ^18.3.1 → 19.1.1
- `react-dom`: ^18.3.1 → 19.1.1
- `@types/react`: ^18.3.3 → 19.1.13
- `@types/react-dom`: ^18.3.0 → 19.1.9
- `@vitejs/plugin-react`: ^4.3.1 → 5.0.3
- `autoprefixer`: ^10.4.19 → 10.4.21
- `eslint`: ^8.57.0 → 9.36.0
- `eslint-plugin-react`: ^7.34.2 → 7.37.5
- `eslint-plugin-react-hooks`: ^4.6.2 → 5.2.0
- `eslint-plugin-react-refresh`: ^0.4.7 → 0.4.20
- `postcss`: ^8.4.39 → 8.5.6
- `tailwindcss`: ^3.4.4 → 4.1.13
- `vite`: ^5.3.1 → 7.1.6


---
[AUTO-GENERATED: DEPENDENCY-SCANNER]