### PR TITLE
Update 14 dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,21 +10,21 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "framer-motion": "^11.3.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "framer-motion": "^12.23.24",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
-    "autoprefixer": "^10.4.19",
-    "eslint": "^8.57.0",
-    "eslint-plugin-react": "^7.34.2",
-    "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-react-refresh": "^0.4.7",
-    "postcss": "^8.4.39",
-    "tailwindcss": "^3.4.4",
-    "vite": "^5.3.1"
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "autoprefixer": "^10.4.22",
+    "eslint": "^9.39.1",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.24",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.17",
+    "vite": "^7.2.4"
   }
 }


### PR DESCRIPTION
## Dependency Updates

This PR updates the following dependencies to their latest versions:

- `framer-motion`: ^11.3.2 → 12.23.24
- `react`: ^18.3.1 → 19.2.0
- `react-dom`: ^18.3.1 → 19.2.0
- `@types/react`: ^18.3.3 → 19.2.7
- `@types/react-dom`: ^18.3.0 → 19.2.3
- `@vitejs/plugin-react`: ^4.3.1 → 5.1.1
- `autoprefixer`: ^10.4.19 → 10.4.22
- `eslint`: ^8.57.0 → 9.39.1
- `eslint-plugin-react`: ^7.34.2 → 7.37.5
- `eslint-plugin-react-hooks`: ^4.6.2 → 7.0.1
- `eslint-plugin-react-refresh`: ^0.4.7 → 0.4.24
- `postcss`: ^8.4.39 → 8.5.6
- `tailwindcss`: ^3.4.4 → 4.1.17
- `vite`: ^5.3.1 → 7.2.4


---
[AUTO-GENERATED: DEPENDENCY-SCANNER]